### PR TITLE
Added minor enhancement in AWS secrets setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,6 @@ on:
 jobs:
   chaos-action:
     runs-on: ubuntu-latest
-    # AWS secrets are required to configure & run chaos
-    env:
-      AWS_SECRET_ACCESS_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -248,11 +242,13 @@ Setup AWS Credentials using [GitHub secrets](https://docs.github.com/en/actions/
 jobs:
   chaos-action:
     runs-on: ubuntu-latest
-    # AWS secrets are required to configure & run chaos
-    env:
-      AWS_SECRET_ACCESS_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 ```
 
-> Note: Either these secrets can be setup at Job level or have to be provided in all chaos-action steps.
+> Note: Either the secrets can be setup like mentioned above & passed to all steps or have to be provided in all chaos-action steps as ENVs.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,9 +19,9 @@ mkdir -p $HOME/go/src/github.com/litmuschaos
 cd ${GOPATH}/src/github.com/litmuschaos/
 dir=${GOPATH}/src/github.com/litmuschaos/chaos-ci-lib
 
-if [[ ! -z $AWS_ACCESS_KEY_ID ]] && [[ ! -z $AWS_SECRET_ACCESS_KEY ]] && [[ ! -z $AWS_REGION ]]
+if [[ ! -z $AWS_ACCESS_KEY_ID ]] && [[ ! -z $AWS_SECRET_ACCESS_KEY ]] && [[ ! -z $AWS_DEFAULT_REGION ]]
 then 
-  aws configure set default.region ${AWS_REGION}
+  aws configure set default.region ${AWS_DEFAULT_REGION}
   aws configure set aws_access_key_id ${AWS_ACCESS_KEY_ID}
   aws configure set aws_secret_access_key ${AWS_SECRET_ACCESS_KEY}
 fi


### PR DESCRIPTION
Signed-off-by: Jonsy13 <vedant.shrotria@chaosnative.com>

We noticed that `aws-actions/configure-aws-credentials@v1` is setting up AWS credentials & providing to all succeeding steps, We don't have to take Credentials as envs at Job level. This PR will update the documentation & make our action compatible with default structure of credentials. 

Tested run - https://github.com/Jonsy13/Providers-Test-Setup/runs/4366087422?check_suite_focus=true