### PR TITLE
Add support for OKE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN chmod +x /usr/local/bin/kubectl
 RUN apt-get update && apt-get install -y git \
     curl \
     unzip \
+    python3-pip \
     && apt-get clean
 
 RUN apt-get update && \
@@ -33,6 +34,8 @@ RUN apt-get update && \
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install
+
+RUN pip install oci-cli
 
 COPY README.md /
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This PR installs the OCI CLI, to authenticate to Oracle Kubernetes Engine. 